### PR TITLE
Download script for consistent working directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+galaxy-zoo-the-galaxy-challenge
+galaxy-zoo-the-galaxy-challenge.zip

--- a/download-data.py
+++ b/download-data.py
@@ -1,0 +1,18 @@
+import io
+import os
+from os import path
+import zipfile
+
+if(not path.isfile('galaxy-zoo-the-galaxy-challenge.zip')):
+    os.system('kaggle competitions download -c galaxy-zoo-the-galaxy-challenge')
+
+if(not path.exists(path.join('galaxy-zoo-the-galaxy-challenge', 'data'))):
+   os.mkdir(path.join('galaxy-zoo-the-galaxy-challenge', 'data'))
+
+with zipfile.ZipFile('galaxy-zoo-the-galaxy-challenge.zip', 'r') as zip_ref:
+    for f in zip_ref.namelist():
+        content = io.BytesIO(zip_ref.read(f))
+        with zipfile.ZipFile(content, 'r') as zip_file:
+            zip_file.extractall(path.join('galaxy-zoo-the-galaxy-challenge', 'data'))
+
+


### PR DESCRIPTION
Wrote up a quick download script in python so we have consistent structures for our working directory.
It as a few prerequisites:

- kaggle package, which you can get from pip install kaggle
- kaggle api token, which you can generate following these instructions https://www.kaggle.com/docs/api

I was not able to find any information regarding the licensing of the dataset we're using so I've also includes a .gitignore to prevent the data from being uploaded to github just to be safe.

The script itself can be ran by running `python download-script.py`.